### PR TITLE
ci: add dependabot.yml and CodeQL workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,93 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '03:00'
+    open-pull-requests-limit: 5
+    groups:
+      # Group TypeScript and related packages
+      typescript:
+        patterns:
+          - 'typescript'
+          - '@typescript-eslint/*'
+          - '@types/*'
+          - 'typescript-eslint'
+          - 'typescript-eslint-parser'
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Group testing frameworks
+      testing:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
+          - 'mocha'
+          - 'chai'
+          - 'sinon'
+          - 'supertest'
+          - 'nyc'
+          - '@testing-library/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Group build tools
+      build-tools:
+        patterns:
+          - 'vite'
+          - '@vitejs/*'
+          - 'tsx'
+          - 'ts-node'
+          - 'nodemon'
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Group React and UI packages
+      react-ui:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - 'react-*'
+          - '@mui/*'
+          - '@emotion/*'
+          - '@hookform/*'
+          - '@tanstack/*'
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Group code quality tools
+      code-quality:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
+          - 'prettier'
+          - 'prettier-*'
+          - 'lint-staged'
+        update-types:
+          - 'minor'
+          - 'patch'
+    labels:
+      - 'dependencies'
+      - 'automated'
+    commit-message:
+      prefix: 'chore(deps)'
+      include: 'scope'
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '03:00'
+    open-pull-requests-limit: 3
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    commit-message:
+      prefix: 'ci'
+      include: 'scope'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: 'CodeQL'
+
+on:
+  push:
+    branches: ['master', 'main', 'develop']
+  pull_request:
+    branches: ['master', 'main']
+  schedule:
+    - cron: '0 0 * * 1' # Weekly on Mondays
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable weekly automated dependency updates via Dependabot, with grouping for TypeScript, testing, build tools, React/UI, and code quality packages
- Adds `.github/workflows/codeql.yml` to run CodeQL static analysis on push/PR to master and weekly on schedule

## Why

iCloud-Frame-Sync was the only active repo in the monorepo group missing both Dependabot configuration and CodeQL scanning. The repo has 50+ dependencies (including 18 major-version lags identified in audit) and 21 high-severity audit findings — automated tracking is overdue.

## Notes

- Uses `npm` (not pnpm) matching the existing CI workflow
- CodeQL uses `javascript` language (covers TypeScript)
- Dependabot groups keep related packages together to reduce PR noise; major bumps (e.g. vite 7→8, react 18→19) will still get individual PRs